### PR TITLE
feat(parsers): support coc.nvim log format

### DIFF
--- a/models/parsers/vscode.ts
+++ b/models/parsers/vscode.ts
@@ -3,7 +3,7 @@ import { Parser } from '../parser-model'
 
 const parser: Parser = {
     name: 'VSCode',
-    lineRegex: /^\[(Trace|Info|Error)\s+-\s+([0-9:APM ]+)\] (?:(Sending|Received) (\w+) |)(.+)/,
+    lineRegex: /^\[(Trace|Info|Error)\s+-\s+([0-9:APM. ]+)\] (?:(Sending|Received) (\w+) |)(.+)/,
     parse(inputLines) {
         const lines = []
         let id = 1


### PR DESCRIPTION
coc.nvim uses a similar trace log format as VSCode, with a little different in timestamp:

VSCode's:

- `[Trace - 4:21:27 PM] Sending request 'initialize - (0)'.`
- `[Trace - 18:47:28] Sending request 'initialize - (0)'.`

coc.nvim's:

`[Trace - 16:06:38.686] Sending request 'initialize - (0)'.`

with three digits of milliseconds.

Tested and passed:

- https://github.com/microsoft/language-server-protocol-inspector/blob/main/lsp-inspector/tests/unit/logParser/fixture/10-tslint-dirty-trace.log
- https://github.com/microsoft/language-server-protocol-inspector/blob/main/lsp-inspector/tests/unit/logParser/fixture/helloworld.log